### PR TITLE
Enable deeplinking

### DIFF
--- a/swagger.go
+++ b/swagger.go
@@ -130,6 +130,7 @@ window.onload = function() {
   // Build a system
   const ui = SwaggerUIBundle({
     url: "{{.Host}}",
+    deepLinking: true,
     dom_id: '#swagger-ui',
     validatorUrl: null,
     presets: [


### PR DESCRIPTION
Enable [deeplinking](https://github.com/swagger-api/swagger-ui/blob/master/docs/usage/deep-linking.md) that helps with sending permalink to a specific API endpoint.