### PR TITLE
Fix about:blank link on doc.json

### DIFF
--- a/swagger.go
+++ b/swagger.go
@@ -129,7 +129,7 @@ const indexTempl = `<!-- HTML for static distribution bundle build -->
 window.onload = function() {
   // Build a system
   const ui = SwaggerUIBundle({
-    url: "{{.Host}}",
+    url: document.location.href.replace("index.html", "") + "{{.Host}}",
     deepLinking: true,
     dom_id: '#swagger-ui',
     validatorUrl: null,


### PR DESCRIPTION
Currently when we have just "doc.json" in URL it's beeing "sanitazed" to "about:blank". To avoid this we adding current sheme/host/base path to it.