### PR TITLE
Added http redirect to index.html

### DIFF
--- a/swagger.go
+++ b/swagger.go
@@ -48,7 +48,7 @@ func Handler(confs ...func(c *Config)) http.HandlerFunc {
 		URL string
 	}
 
-	var re = regexp.MustCompile(`(.*)(index\.html|doc\.json|favicon-16x16\.png|favicon-32x32\.png|/oauth2-redirect\.html|swagger-ui\.css|swagger-ui\.css\.map|swagger-ui\.js|swagger-ui\.js\.map|swagger-ui-bundle\.js|swagger-ui-bundle\.js\.map|swagger-ui-standalone-preset\.js|swagger-ui-standalone-preset\.js\.map)[\?|.]*`)
+	var re = regexp.MustCompile(`^(.*\/)([^\?].*)?[\?|.]*$`)
 
 	return func(w http.ResponseWriter, r *http.Request) {
 		var matches []string
@@ -74,6 +74,8 @@ func Handler(confs ...func(c *Config)) http.HandlerFunc {
 				panic(err)
 			}
 			w.Write([]byte(doc))
+		case "":
+			http.Redirect(w, r, prefix + "index.html", 301)
 		default:
 			h.ServeHTTP(w, r)
 		}

--- a/swagger.go
+++ b/swagger.go
@@ -51,13 +51,7 @@ func Handler(confs ...func(c *Config)) http.HandlerFunc {
 	var re = regexp.MustCompile(`^(.*\/)([^\?].*)?[\?|.]*$`)
 
 	return func(w http.ResponseWriter, r *http.Request) {
-		var matches []string
-		if matches = re.FindStringSubmatch(r.RequestURI); len(matches) != 3 {
-			w.Header().Set("Content-Type", "text/plain; charset=utf-8")
-			w.WriteHeader(http.StatusNotFound)
-			w.Write([]byte(http.StatusText(http.StatusNotFound)))
-			return
-		}
+		matches := re.FindStringSubmatch(r.RequestURI)
 		path := matches[2]
 		prefix := matches[1]
 		h.Prefix = prefix

--- a/swagger_test.go
+++ b/swagger_test.go
@@ -26,6 +26,9 @@ func TestWrapHandler(t *testing.T) {
 
 	w4 := performRequest("GET", "/notfound", router)
 	assert.Equal(t, 404, w4.Code)
+
+	w5 := performRequest("GET", "/", router)
+	assert.Equal(t, 301, w5.Code)
 }
 
 func performRequest(method, target string, h http.Handler) *httptest.ResponseRecorder {


### PR DESCRIPTION
The Handler has been extended, so that requests that don't have a filename in the path get redirected to the swagger index.html.

Additionally, the regexp for the filename validation has been cleaned up and the filename whitelist has been removed. The implementation now relies on the webdav Handler to create a 404 response if a file can't be found.