### PR TITLE
Send the right content-type for doc.json

### DIFF
--- a/swagger.go
+++ b/swagger.go
@@ -79,6 +79,7 @@ func Handler(configFns ...func(*Config)) http.HandlerFunc {
 		case "index.html":
 			_ = index.Execute(w, config)
 		case "doc.json":
+			w.Header().Set("Content-Type", "application/json; charset=utf-8")
 			doc, err := swag.ReadDoc()
 			if err != nil {
 				panic(err)

--- a/swagger_test.go
+++ b/swagger_test.go
@@ -20,6 +20,7 @@ func TestWrapHandler(t *testing.T) {
 
 	w2 := performRequest("GET", "/doc.json", router)
 	assert.Equal(t, 200, w2.Code)
+	assert.Equal(t, "application/json; charset=utf-8", w2.Header().Get("content-type"))
 
 	w3 := performRequest("GET", "/favicon-16x16.png", router)
 	assert.Equal(t, 200, w3.Code)


### PR DESCRIPTION
Send it explicitly with `application/json; charset=utf-8`, otherwise it's sent with `text/plain; charset=utf-8`.