### PR TITLE
Add flag for OAuth2RedirectURL

### DIFF
--- a/swagger.go
+++ b/swagger.go
@@ -15,10 +15,11 @@ var WrapHandler = Handler()
 // Config stores httpSwagger configuration variables.
 type Config struct {
 	//The url pointing to API definition (normally swagger.json or swagger.yaml). Default is `doc.json`.
-	URL          string
-	DeepLinking  bool
-	DocExpansion string
-	DomID        string
+	URL               string
+	DeepLinking       bool
+	DocExpansion      string
+	DomID             string
+	OAuth2RedirectURL template.JSStr
 }
 
 // URL presents the url pointing to API definition (normally swagger.json or swagger.yaml).
@@ -49,13 +50,21 @@ func DomID(domID string) func(c *Config) {
 	}
 }
 
+// OAuth2RedirectURL is the URL where OAuth2 responses are redirected to.
+func OAuth2RedirectURL(oauth2RedirectURL string) func(c *Config) {
+	return func(c *Config) {
+		c.OAuth2RedirectURL = template.JSStr(oauth2RedirectURL)
+	}
+}
+
 // Handler wraps `http.Handler` into `http.HandlerFunc`.
 func Handler(configFns ...func(*Config)) http.HandlerFunc {
 	config := &Config{
-		URL:          "doc.json",
-		DeepLinking:  true,
-		DocExpansion: "list",
-		DomID:        "#swagger-ui",
+		URL:               "doc.json",
+		DeepLinking:       true,
+		DocExpansion:      "list",
+		DomID:             "#swagger-ui",
+		OAuth2RedirectURL: "",
 	}
 	for _, configFn := range configFns {
 		configFn(config)
@@ -171,6 +180,7 @@ window.onload = function() {
     deepLinking: {{.DeepLinking}},
     docExpansion: "{{.DocExpansion}}",
     dom_id: "{{.DomID}}",
+    {{ if .OAuth2RedirectURL}}oauth2RedirectUrl: {{.OAuth2RedirectURL}},{{end -}}
     validatorUrl: null,
     presets: [
       SwaggerUIBundle.presets.apis,


### PR DESCRIPTION
When attempting to authenticate via OAuth, the authentication server will redirect to a URL given in the request. By default this seems to be `$server/oauth2-redirect.html`, which fails when the handler is attached to a different path (the file `oauth2-redirect.html` is provided by Swagger UI and included in `swaggo/files`).

This PR adds a configuration option for the parameter [oauth2RedirectUrl](https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/#network) which allows setting the correct value.

Note: This should be set to an absolute URL.