### PR TITLE
Fixed http-swagger gorilla example

### DIFF
--- a/example/gorilla/main.go
+++ b/example/gorilla/main.go
@@ -30,7 +30,7 @@ func main() {
 		httpSwagger.URL("http://localhost:1323/swagger/doc.json"), //The url pointing to API definition
 		httpSwagger.DeepLinking(true),
 		httpSwagger.DocExpansion("none"),
-		httpSwagger.DomID("#swagger-ui"),
+		httpSwagger.DomID("swagger-ui"),
 	)).Methods(http.MethodGet)
 
 	log.Fatal(http.ListenAndServe(":1323", r))


### PR DESCRIPTION
**Describe the PR**
Fixed typo in Swagger UI DomID definition. It seems that "#' is automatically added, without the need of specifying it when passing the argument to httpSwagger.DomID.

**Relation issue**
e.g. https://github.com/swaggo/gin-swagger/pull/123/files

