### PR TITLE
Modify swagger layout

### DIFF
--- a/swagger.go
+++ b/swagger.go
@@ -27,6 +27,7 @@ type Config struct {
 	UIConfig             map[template.JS]template.JS
 	DeepLinking          bool
 	PersistAuthorization bool
+	Layout				 string
 }
 
 // URL presents the url pointing to API definition (normally swagger.json or swagger.yaml).
@@ -110,6 +111,19 @@ func AfterScript(js string) func(*Config) {
 	}
 }
 
+type Layouts string
+const (
+	BaseLayout Layouts = "BaseLayout"
+	StandaloneLayout Layouts = "StandaloneLayout"
+)
+
+// Define Layout options are BaseLayout or StandaloneLayout
+func Layout(layout Layouts) func(*Config) {
+	return func(c *Config) {
+		c.Layout = string(layout)
+	}
+}
+
 func newConfig(configFns ...func(*Config)) *Config {
 	config := Config{
 		URL:                  "doc.json",
@@ -118,6 +132,7 @@ func newConfig(configFns ...func(*Config)) *Config {
 		InstanceName:         "swagger",
 		DeepLinking:          true,
 		PersistAuthorization: false,
+		Layout:     		  string(StandaloneLayout),
 	}
 
 	for _, fn := range configFns {
@@ -285,7 +300,7 @@ window.onload = function() {
     {{- range $k, $v := .UIConfig}}
     {{$k}}: {{$v}},
     {{- end}}
-    layout: "StandaloneLayout"
+    layout: "{{$.Layout}}"
   })
 
   window.ui = ui

--- a/swagger.go
+++ b/swagger.go
@@ -27,7 +27,7 @@ type Config struct {
 	UIConfig             map[template.JS]template.JS
 	DeepLinking          bool
 	PersistAuthorization bool
-	Layout				 string
+	Layout               string
 }
 
 // URL presents the url pointing to API definition (normally swagger.json or swagger.yaml).
@@ -132,7 +132,7 @@ func newConfig(configFns ...func(*Config)) *Config {
 		InstanceName:         "swagger",
 		DeepLinking:          true,
 		PersistAuthorization: false,
-		Layout:     		  string(StandaloneLayout),
+		Layout:               string(StandaloneLayout),
 	}
 
 	for _, fn := range configFns {


### PR DESCRIPTION
**Description**
Currently swaggo doesn't allow to modify the layout and I found sometimes it is useful to have the option to switch between the base and the standalone layouts, so this script implements that method.

**Relation issue**
[Issue 86](https://github.com/swaggo/http-swagger/issues/86)
