### PR TITLE
Explictly WriteHeader before Write to avoid superfluous response.Writ…

### DIFF
--- a/swagger.go
+++ b/swagger.go
@@ -173,6 +173,7 @@ func Handler(configFns ...func(*Config)) http.HandlerFunc {
 
 		switch path {
 		case "index.html":
+			w.WriteHeader(http.StatusOK)
 			_ = index.Execute(w, config)
 		case "doc.json":
 			doc, err := swag.ReadDoc(config.InstanceName)
@@ -181,7 +182,7 @@ func Handler(configFns ...func(*Config)) http.HandlerFunc {
 
 				return
 			}
-
+			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte(doc))
 		case "":
 			http.Redirect(w, r, handler.Prefix+"index.html", http.StatusMovedPermanently)


### PR DESCRIPTION
There're some situation when `WriteHeader` would be called after `httpSwagger.Handler` which may cause warning of `http: superfluous response.WriteHeader call`.

Simply add `WriteHeader` before write data to response solve this problem. The underlying `webdav.Handler` does the same and won't cause this problem.

Reference to https://github.com/golang/go/blob/72301a9863fb43ff26e9779a086e02cf02031ceb/src/net/http/clientserver_test.go#L1551