### PR TITLE
Parse url path to extract query parameters from filename when calling embed.FS

### DIFF
--- a/swagger.go
+++ b/swagger.go
@@ -3,6 +3,7 @@ package httpSwagger
 import (
 	"html/template"
 	"net/http"
+	"net/url"
 	"path/filepath"
 	"regexp"
 
@@ -196,7 +197,13 @@ func Handler(configFns ...func(*Config)) http.HandlerFunc {
 		case "":
 			http.Redirect(w, r, matches[1]+"/"+"index.html", http.StatusMovedPermanently)
 		default:
-			r.URL.Path = matches[2]
+			var err error
+			r.URL, err = url.Parse(matches[2])
+			if err != nil {
+				http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+
+				return
+			}
 			http.FileServer(http.FS(swaggerFiles.FS)).ServeHTTP(w, r)
 		}
 	}

--- a/swagger_test.go
+++ b/swagger_test.go
@@ -96,6 +96,10 @@ func TestWrapHandler(t *testing.T) {
 		assert.Equal(t, http.StatusOK, w5.Code)
 		assert.Equal(t, w5.Header()["Content-Type"][0], "application/javascript")
 
+		w6 := performRequest(http.MethodGet, test.RootFolder+"oauth2-redirect.html?state=0&session_state=1&code=2", router)
+		assert.Equal(t, http.StatusOK, w6.Code)
+		assert.Equal(t, w6.Header()["Content-Type"][0], "text/html; charset=utf-8")
+
 		assert.Equal(t, http.StatusNotFound, performRequest(http.MethodGet, test.RootFolder+"notfound", router).Code)
 
 		assert.Equal(t, 301, performRequest(http.MethodGet, test.RootFolder, router).Code)


### PR DESCRIPTION
I found that `oauth-redirect.html` is broken in latest version since it return 404 not found when query parameters are present (which are to be expected during an oauth process)

I think it was introduced in https://github.com/swaggo/http-swagger/pull/100

This simply fix the issue by parsing the relative path with `url.Parse` before sending it to embed.FS.

I added a test similar to what is to be expected from an oauth process. 
The same test previously passed successfully on v2.0.0.