### PR TITLE
feat(config): add DefaultModelsExpandDepth set the default expansion depth for models

### DIFF
--- a/swagger.go
+++ b/swagger.go
@@ -16,17 +16,18 @@ var WrapHandler = Handler()
 // Config stores httpSwagger configuration variables.
 type Config struct {
 	// The url pointing to API definition (normally swagger.json or swagger.yaml). Default is `doc.json`.
-	URL                  string
-	DocExpansion         string
-	DomID                string
-	InstanceName         string
-	BeforeScript         template.JS
-	AfterScript          template.JS
-	Plugins              []template.JS
-	UIConfig             map[template.JS]template.JS
-	DeepLinking          bool
-	PersistAuthorization bool
-	Layout               SwaggerLayout
+	URL                      string
+	DocExpansion             string
+	DomID                    string
+	InstanceName             string
+	BeforeScript             template.JS
+	AfterScript              template.JS
+	Plugins                  []template.JS
+	UIConfig                 map[template.JS]template.JS
+	DeepLinking              bool
+	PersistAuthorization     bool
+	Layout                   SwaggerLayout
+	DefaultModelsExpandDepth ModelsExpandDepthType
 }
 
 // URL presents the url pointing to API definition (normally swagger.json or swagger.yaml).
@@ -124,15 +125,30 @@ func Layout(layout SwaggerLayout) func(*Config) {
 	}
 }
 
+type ModelsExpandDepthType int
+
+const (
+	ShowModel ModelsExpandDepthType = 1
+	HideModel ModelsExpandDepthType = -1
+)
+
+// DefaultModelsExpandDepth presents the model of response and request.
+func DefaultModelsExpandDepth(defaultModelsExpandDepth ModelsExpandDepthType) func(*Config) {
+	return func(c *Config) {
+		c.DefaultModelsExpandDepth = defaultModelsExpandDepth
+	}
+}
+
 func newConfig(configFns ...func(*Config)) *Config {
 	config := Config{
-		URL:                  "doc.json",
-		DocExpansion:         "list",
-		DomID:                "swagger-ui",
-		InstanceName:         "swagger",
-		DeepLinking:          true,
-		PersistAuthorization: false,
-		Layout:               StandaloneLayout,
+		URL:                      "doc.json",
+		DocExpansion:             "list",
+		DomID:                    "swagger-ui",
+		InstanceName:             "swagger",
+		DeepLinking:              true,
+		PersistAuthorization:     false,
+		Layout:                   StandaloneLayout,
+		DefaultModelsExpandDepth: ShowModel,
 	}
 
 	for _, fn := range configFns {
@@ -296,7 +312,8 @@ window.onload = function() {
     {{- range $k, $v := .UIConfig}}
     {{$k}}: {{$v}},
     {{- end}}
-    layout: "{{$.Layout}}"
+    layout: "{{$.Layout}}",
+    defaultModelsExpandDepth: {{.DefaultModelsExpandDepth}}
   })
 
   window.ui = ui

--- a/swagger_test.go
+++ b/swagger_test.go
@@ -377,12 +377,13 @@ func TestUIConfigOptions(t *testing.T) {
 		{
 			desc: "default configuration",
 			cfg: &Config{
-				URL:                  "doc.json",
-				DeepLinking:          true,
-				DocExpansion:         "list",
-				DomID:                "swagger-ui",
-				PersistAuthorization: false,
-				Layout:               StandaloneLayout,
+				URL:                      "doc.json",
+				DeepLinking:              true,
+				DocExpansion:             "list",
+				DomID:                    "swagger-ui",
+				PersistAuthorization:     false,
+				Layout:                   StandaloneLayout,
+				DefaultModelsExpandDepth: ShowModel,
 			},
 			exp: `window.onload = function() {
   
@@ -400,7 +401,8 @@ func TestUIConfigOptions(t *testing.T) {
     plugins: [
       SwaggerUIBundle.plugins.DownloadUrl
     ],
-    layout: "StandaloneLayout"
+    layout: "StandaloneLayout",
+    defaultModelsExpandDepth:  1 
   })
 
   window.ui = ui
@@ -432,6 +434,7 @@ func TestUIConfigOptions(t *testing.T) {
 					"onComplete":            `() => { window.ui.setBasePath('v3'); }`,
 					"defaultModelRendering": `"model"`,
 				},
+				DefaultModelsExpandDepth: HideModel,
 			},
 			exp: `window.onload = function() {
   const SomePlugin = (system) => ({
@@ -458,7 +461,8 @@ func TestUIConfigOptions(t *testing.T) {
     defaultModelRendering: "model",
     onComplete: () => { window.ui.setBasePath('v3'); },
     showExtensions: true,
-    layout: "StandaloneLayout"
+    layout: "StandaloneLayout",
+    defaultModelsExpandDepth:  -1 
   })
 
   window.ui = ui
@@ -536,4 +540,18 @@ func TestUIConfigOptions(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDefaultModelsExpandDepth(t *testing.T) {
+	cfg := newConfig()
+	// Default value
+	assert.Equal(t, ShowModel, cfg.DefaultModelsExpandDepth)
+
+	// Set -1
+	DefaultModelsExpandDepth(HideModel)(cfg)
+	assert.Equal(t, HideModel, cfg.DefaultModelsExpandDepth)
+
+	// Set false
+	DefaultModelsExpandDepth(ShowModel)(cfg)
+	assert.Equal(t, ShowModel, cfg.DefaultModelsExpandDepth)
 }


### PR DESCRIPTION
**Describe the PR**
This PR aims to enhance the Swagger UI configuration by providing the ability to hide the model information. Currently, the Swagger UI displays model details, which might not be desirable in certain scenarios.

**Relation issue**
https://github.com/swaggo/http-swagger/issues/106

**Additional context**

Introduce a new configuration option for Swagger UI to control the visibility of models.
Implement the necessary changes in the API or parameters to enable hiding the model information.
Update documentation to include details about the new configuration option and its usage.

Improved user experience by reducing clutter and focusing on relevant API details.
Increased flexibility in customizing the Swagger UI according to specific project requirements.


Please review the changes and provide any feedback or suggestions. This enhancement will contribute to a more user-friendly and streamlined Swagger UI experience.
