### PR TITLE
feat: allow for displaying extensions in the UI

### DIFF
--- a/swagger.go
+++ b/swagger.go
@@ -29,6 +29,7 @@ type Config struct {
 	PersistAuthorization     bool
 	Layout                   SwaggerLayout
 	DefaultModelsExpandDepth ModelsExpandDepthType
+	ShowExtensions           bool
 }
 
 // URL presents the url pointing to API definition (normally swagger.json or swagger.yaml).
@@ -141,6 +142,14 @@ func DefaultModelsExpandDepth(defaultModelsExpandDepth ModelsExpandDepthType) fu
 	}
 }
 
+// ShowExtensions controls the display of vendor extension (x-) fields and values for Operations,
+// Parameters, Responses, and Schema.
+func ShowExtensions(showExtensions bool) func(config *Config) {
+	return func(c *Config) {
+		c.ShowExtensions = showExtensions
+	}
+}
+
 func newConfig(configFns ...func(*Config)) *Config {
 	config := Config{
 		URL:                      "doc.json",
@@ -151,6 +160,7 @@ func newConfig(configFns ...func(*Config)) *Config {
 		PersistAuthorization:     false,
 		Layout:                   StandaloneLayout,
 		DefaultModelsExpandDepth: ShowModel,
+		ShowExtensions:           false,
 	}
 
 	for _, fn := range configFns {
@@ -321,7 +331,8 @@ window.onload = function() {
     {{$k}}: {{$v}},
     {{- end}}
     layout: "{{$.Layout}}",
-    defaultModelsExpandDepth: {{.DefaultModelsExpandDepth}}
+    defaultModelsExpandDepth: {{.DefaultModelsExpandDepth}},
+    showExtensions: {{.ShowExtensions}}
   })
 
   window.ui = ui

--- a/swagger_test.go
+++ b/swagger_test.go
@@ -559,3 +559,16 @@ func TestDefaultModelsExpandDepth(t *testing.T) {
 	DefaultModelsExpandDepth(ShowModel)(cfg)
 	assert.Equal(t, ShowModel, cfg.DefaultModelsExpandDepth)
 }
+
+func TestShowExtensions(t *testing.T) {
+	var cfg *Config
+
+	cfg = newConfig()
+	assert.False(t, cfg.ShowExtensions)
+
+	cfg = newConfig(ShowExtensions(true))
+	assert.True(t, cfg.ShowExtensions)
+
+	cfg = newConfig(ShowExtensions(false))
+	assert.False(t, cfg.ShowExtensions)
+}


### PR DESCRIPTION
Allow for controlling the flag `showExtensions` ([docs](https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/)).
