### PR TITLE
separated index.html and index.js to prevent unsafe-inline

### DIFF
--- a/swagger.go
+++ b/swagger.go
@@ -171,6 +171,7 @@ func Handler(configFns ...func(*Config)) http.HandlerFunc {
 
 	// create a template with name
 	index, _ := template.New("swagger_index.html").Parse(indexTempl)
+	indexJs, _ := template.New("swagger_index.js").Parse(indexJsTempl)
 
 	re := regexp.MustCompile(`^(.*/)([^?].*)?[?|.]*$`)
 
@@ -202,6 +203,8 @@ func Handler(configFns ...func(*Config)) http.HandlerFunc {
 		switch path {
 		case "index.html":
 			_ = index.Execute(w, config)
+		case "index.js":
+			_ = indexJs.Execute(w, config)
 		case "doc.json":
 			doc, err := swag.ReadDoc(config.InstanceName)
 			if err != nil {
@@ -225,6 +228,43 @@ func Handler(configFns ...func(*Config)) http.HandlerFunc {
 		}
 	}
 }
+
+const indexJsTempl = `
+window.onload = function() {
+  {{- if .BeforeScript}}
+  {{.BeforeScript}}
+  {{- end}}
+  // Build a system
+  const ui = SwaggerUIBundle({
+    url: "{{.URL}}",
+    deepLinking: {{.DeepLinking}},
+    docExpansion: "{{.DocExpansion}}",
+    dom_id: "#{{.DomID}}",
+    persistAuthorization: {{.PersistAuthorization}},
+    validatorUrl: null,
+    presets: [
+      SwaggerUIBundle.presets.apis,
+      SwaggerUIStandalonePreset
+    ],
+    plugins: [
+      SwaggerUIBundle.plugins.DownloadUrl
+      {{- range $plugin := .Plugins }},
+      {{$plugin}}
+      {{- end}}
+    ],
+    {{- range $k, $v := .UIConfig}}
+    {{$k}}: {{$v}},
+    {{- end}}
+    layout: "{{$.Layout}}",
+    defaultModelsExpandDepth: {{.DefaultModelsExpandDepth}}
+  })
+
+  window.ui = ui
+  {{- if .AfterScript}}
+  {{.AfterScript}}
+  {{- end}}
+}
+`
 
 const indexTempl = `<!-- HTML for static distribution bundle build -->
 <!DOCTYPE html>
@@ -292,44 +332,9 @@ const indexTempl = `<!-- HTML for static distribution bundle build -->
 
 <div id="swagger-ui"></div>
 
+<script src="./index.js"> </script>
 <script src="./swagger-ui-bundle.js"> </script>
 <script src="./swagger-ui-standalone-preset.js"> </script>
-<script>
-window.onload = function() {
-  {{- if .BeforeScript}}
-  {{.BeforeScript}}
-  {{- end}}
-  // Build a system
-  const ui = SwaggerUIBundle({
-    url: "{{.URL}}",
-    deepLinking: {{.DeepLinking}},
-    docExpansion: "{{.DocExpansion}}",
-    dom_id: "#{{.DomID}}",
-    persistAuthorization: {{.PersistAuthorization}},
-    validatorUrl: null,
-    presets: [
-      SwaggerUIBundle.presets.apis,
-      SwaggerUIStandalonePreset
-    ],
-    plugins: [
-      SwaggerUIBundle.plugins.DownloadUrl
-      {{- range $plugin := .Plugins }},
-      {{$plugin}}
-      {{- end}}
-    ],
-    {{- range $k, $v := .UIConfig}}
-    {{$k}}: {{$v}},
-    {{- end}}
-    layout: "{{$.Layout}}",
-    defaultModelsExpandDepth: {{.DefaultModelsExpandDepth}}
-  })
-
-  window.ui = ui
-  {{- if .AfterScript}}
-  {{.AfterScript}}
-  {{- end}}
-}
-</script>
 </body>
 
 </html>


### PR DESCRIPTION
**Describe the PR**
separate index.html and index.js

**Relation issue**
the index.html with included javascript causes unsafe inline errors:
![image](https://github.com/user-attachments/assets/f7605f68-27e3-42ff-b99f-69d1f9cfcc83)
![image](https://github.com/user-attachments/assets/1f9782a8-ad67-49cf-85b0-b0e40a35ee60)
