### PR TITLE
Fix issue with RequestURI that arises in tests

### DIFF
--- a/swagger.go
+++ b/swagger.go
@@ -191,7 +191,7 @@ func Handler(configFns ...func(*Config)) http.HandlerFunc {
 			return
 		}
 
-		matches := re.FindStringSubmatch(r.RequestURI)
+		matches := re.FindStringSubmatch(r.URL.Path)
 
 		path := matches[2]
 


### PR DESCRIPTION
**Describe the PR**
Although RequestURI and the URL field are supposed to be the same, sometimes they are inconsistent:
"RequestURI is the unmodified request-target of the Request-Line (RFC 7230, Section 3.1.1) as sent by the client to a server. Usually the URL field should be used instead."

When running automated tests with `http.NewRequest` from net/http, the RequestURI field is unfortunately not set. Hence, by replacing RequestURI by the path field we fix those issues.

**Relation issue**
#99, https://github.com/golang/go/issues/12613

**Additional context**
The way it is, when running tests with `http.NewRequest`, the following panic occurs:
```
--- FAIL: TestSwaggerRouter (0.00s)
    --- FAIL: TestSwaggerRouter/Allows_access_with_correct_Basic_Auth (0.00s)
panic: runtime error: index out of range [2] with length 0 [recovered]
	panic: runtime error: index out of range [2] with length 0

goroutine 56 [running]:
testing.tRunner.func1.2({0x1042e03c0, 0x14000056c60})
	.../go/src/testing/testing.go:1632 +0x1bc
testing.tRunner.func1()
	.../go/src/testing/testing.go:1635 +0x334
panic({0x1042e03c0?, 0x14000056c60?})
	.../go/src/runtime/panic.go:785 +0x124
github.com/swaggo/http-swagger/v2.Handler.func1({0x1043e6ae8, 0x1400090e5c0}, 0x14000926500)
	.../go/pkg/mod/github.com/swaggo/http-swagger/v2@v2.0.2/swagger.go:186 +0x798
net/http.HandlerFunc.ServeHTTP(0x14000891560?, {0x1043e6ae8?, 0x1400090e5c0?}, 0x10357fcef?)
```
