### PR TITLE
feat: Adding Support for SyntaxHighlight options & Fix swagger_test.go

### DIFF
--- a/swagger.go
+++ b/swagger.go
@@ -30,6 +30,7 @@ type Config struct {
 	Layout                   SwaggerLayout
 	DefaultModelsExpandDepth ModelsExpandDepthType
 	ShowExtensions           bool
+	SyntaxHighlight          bool
 }
 
 // URL presents the url pointing to API definition (normally swagger.json or swagger.yaml).
@@ -105,6 +106,13 @@ func BeforeScript(js string) func(*Config) {
 	}
 }
 
+// SyntaxHighlight true, false.
+func SyntaxHighlight(syntaxHighlight bool) func(*Config) {
+	return func(c *Config) {
+		c.SyntaxHighlight = syntaxHighlight
+	}
+}
+
 // AfterScript holds JavaScript to be run right after the Swagger UI object is created
 // and set on the window.
 func AfterScript(js string) func(*Config) {
@@ -161,6 +169,7 @@ func newConfig(configFns ...func(*Config)) *Config {
 		Layout:                   StandaloneLayout,
 		DefaultModelsExpandDepth: ShowModel,
 		ShowExtensions:           false,
+		SyntaxHighlight:          true,
 	}
 
 	for _, fn := range configFns {
@@ -312,6 +321,7 @@ window.onload = function() {
   // Build a system
   const ui = SwaggerUIBundle({
     url: "{{.URL}}",
+    syntaxHighlight: {{.SyntaxHighlight}},
     deepLinking: {{.DeepLinking}},
     docExpansion: "{{.DocExpansion}}",
     dom_id: "#{{.DomID}}",

--- a/swagger_test.go
+++ b/swagger_test.go
@@ -382,17 +382,20 @@ func TestUIConfigOptions(t *testing.T) {
 			desc: "default configuration",
 			cfg: &Config{
 				URL:                      "doc.json",
+				SyntaxHighlight:	  true,
 				DeepLinking:              true,
 				DocExpansion:             "list",
 				DomID:                    "swagger-ui",
 				PersistAuthorization:     false,
 				Layout:                   StandaloneLayout,
 				DefaultModelsExpandDepth: ShowModel,
+				ShowExtensions:		  true,
 			},
 			exp: `window.onload = function() {
   
   const ui = SwaggerUIBundle({
     url: "doc.json",
+    syntaxHighlight:  true ,
     deepLinking:  true ,
     docExpansion: "list",
     dom_id: "#swagger-ui",
@@ -406,7 +409,8 @@ func TestUIConfigOptions(t *testing.T) {
       SwaggerUIBundle.plugins.DownloadUrl
     ],
     layout: "StandaloneLayout",
-    defaultModelsExpandDepth:  1 
+    defaultModelsExpandDepth:  1 ,
+    showExtensions:  true 
   })
 
   window.ui = ui
@@ -416,11 +420,13 @@ func TestUIConfigOptions(t *testing.T) {
 			desc: "script configuration",
 			cfg: &Config{
 				URL:                  "swagger.json",
+				SyntaxHighlight:      true,
 				DeepLinking:          false,
 				PersistAuthorization: true,
 				DocExpansion:         "none",
 				DomID:                "swagger-ui-id",
 				Layout:               StandaloneLayout,
+				ShowExtensions:	      true,
 				BeforeScript: `const SomePlugin = (system) => ({
     // Some plugin
   });
@@ -434,7 +440,6 @@ func TestUIConfigOptions(t *testing.T) {
 					"AnotherPlugin",
 				},
 				UIConfig: map[template.JS]template.JS{
-					"showExtensions":        "true",
 					"onComplete":            `() => { window.ui.setBasePath('v3'); }`,
 					"defaultModelRendering": `"model"`,
 				},
@@ -448,6 +453,7 @@ func TestUIConfigOptions(t *testing.T) {
   
   const ui = SwaggerUIBundle({
     url: "swagger.json",
+    syntaxHighlight:  true ,
     deepLinking:  false ,
     docExpansion: "none",
     dom_id: "#swagger-ui-id",
@@ -464,9 +470,9 @@ func TestUIConfigOptions(t *testing.T) {
     ],
     defaultModelRendering: "model",
     onComplete: () => { window.ui.setBasePath('v3'); },
-    showExtensions: true,
     layout: "StandaloneLayout",
-    defaultModelsExpandDepth:  -1 
+    defaultModelsExpandDepth:  -1 ,
+    showExtensions:  true 
   })
 
   window.ui = ui
@@ -529,12 +535,12 @@ func TestUIConfigOptions(t *testing.T) {
 			for i, expln := range explns {
 				if i >= buflen {
 					printContext(i)
-					t.Fatalf(`first unequal line: expected "%s" but got EOF`, expln)
+					t.Fatalf(`first unequal line on line %d: expected "%s" but got EOF`, i, expln)
 				}
 				bufln := buflns[i]
 				if bufln != expln {
 					printContext(i)
-					t.Fatalf(`first unequal line: expected "%s" but got "%s"`, expln, bufln)
+					t.Fatalf(`first unequal line on line %d: expected "%s" but got "%s"`, i, expln, bufln)
 				}
 			}
 


### PR DESCRIPTION
**Describe the PR**
Adding options to disable and enable Syntax Highlight in swagger configuration. This code based on `echo-swagger` pull request [here](https://github.com/swaggo/echo-swagger/pull/91)

**Relation issue**
N/A

**Additional context**
Exposing this option is necessary when dealing with large payload, otherwise, the syntax highlighting hangs swagger ui.
https://github.com/swaggo/echo-swagger/pull/91