### PR TITLE
Add support of query string to swagger UI

### DIFF
--- a/swagger.go
+++ b/swagger.go
@@ -191,7 +191,7 @@ func Handler(configFns ...func(*Config)) http.HandlerFunc {
 			return
 		}
 
-		matches := re.FindStringSubmatch(r.RequestURI)
+		matches := re.FindStringSubmatch(r.URL.Path)
 
 		path := matches[2]
 
@@ -222,7 +222,11 @@ func Handler(configFns ...func(*Config)) http.HandlerFunc {
 
 			_, _ = w.Write([]byte(doc))
 		case "":
-			http.Redirect(w, r, matches[1]+"/"+"index.html", http.StatusMovedPermanently)
+			query := r.URL.RawQuery
+			if query != "" {
+				query = "?" + query
+			}
+			http.Redirect(w, r, matches[1]+"/"+"index.html"+query, http.StatusMovedPermanently)
 		default:
 			var err error
 			r.URL, err = url.Parse(matches[2])

--- a/swagger_test.go
+++ b/swagger_test.go
@@ -107,6 +107,12 @@ func TestWrapHandler(t *testing.T) {
 		assert.Equal(t, http.StatusMethodNotAllowed, performRequest(http.MethodPost, test.RootFolder+"index.html", router).Code)
 
 		assert.Equal(t, http.StatusMethodNotAllowed, performRequest(http.MethodPut, test.RootFolder+"index.html", router).Code)
+
+		w7 := performRequest(http.MethodGet, test.RootFolder+"index.html?param=value&another=value", router)
+		assert.Equal(t, http.StatusOK, w7.Code)
+		assert.Equal(t, w7.Header()["Content-Type"][0], "text/html; charset=utf-8")
+
+		assert.Equal(t, 301, performRequest(http.MethodGet, test.RootFolder+"?param=value&another=value", router).Code)
 	}
 }
 


### PR DESCRIPTION
**Describe the PR**
Add support of query string to swagger UI. 

For example:
 `https://my.swagger.io/index.html?urls.primaryName=my-cool-functions`

**Relation issue**
https://github.com/swaggo/http-swagger/issues/130

**Additional context**
Pulled fixed by @KaiReichart tests and force pushed


